### PR TITLE
Fix the Inheritable capability defaults.

### DIFF
--- a/oci/spec.go
+++ b/oci/spec.go
@@ -148,10 +148,9 @@ func populateDefaultUnixSpec(ctx context.Context, s *Spec, id string) error {
 				GID: 0,
 			},
 			Capabilities: &specs.LinuxCapabilities{
-				Bounding:    defaultUnixCaps(),
-				Permitted:   defaultUnixCaps(),
-				Inheritable: defaultUnixCaps(),
-				Effective:   defaultUnixCaps(),
+				Bounding:  defaultUnixCaps(),
+				Permitted: defaultUnixCaps(),
+				Effective: defaultUnixCaps(),
 			},
 			Rlimits: []specs.POSIXRlimit{
 				{

--- a/oci/spec_opts.go
+++ b/oci/spec_opts.go
@@ -770,7 +770,6 @@ func WithCapabilities(caps []string) SpecOpts {
 		s.Process.Capabilities.Bounding = caps
 		s.Process.Capabilities.Effective = caps
 		s.Process.Capabilities.Permitted = caps
-		s.Process.Capabilities.Inheritable = caps
 
 		return nil
 	}
@@ -828,7 +827,6 @@ func WithAddedCapabilities(caps []string) SpecOpts {
 				&s.Process.Capabilities.Bounding,
 				&s.Process.Capabilities.Effective,
 				&s.Process.Capabilities.Permitted,
-				&s.Process.Capabilities.Inheritable,
 			} {
 				if !capsContain(*cl, c) {
 					*cl = append(*cl, c)
@@ -848,7 +846,6 @@ func WithDroppedCapabilities(caps []string) SpecOpts {
 				&s.Process.Capabilities.Bounding,
 				&s.Process.Capabilities.Effective,
 				&s.Process.Capabilities.Permitted,
-				&s.Process.Capabilities.Inheritable,
 			} {
 				removeCap(cl, c)
 			}
@@ -863,7 +860,7 @@ func WithDroppedCapabilities(caps []string) SpecOpts {
 func WithAmbientCapabilities(caps []string) SpecOpts {
 	return func(_ context.Context, _ Client, _ *containers.Container, s *Spec) error {
 		setCapabilities(s)
-
+		s.Process.Capabilities.Inheritable = caps
 		s.Process.Capabilities.Ambient = caps
 		return nil
 	}

--- a/oci/spec_opts_test.go
+++ b/oci/spec_opts_test.go
@@ -561,7 +561,6 @@ func TestAddCaps(t *testing.T) {
 		s.Process.Capabilities.Bounding,
 		s.Process.Capabilities.Effective,
 		s.Process.Capabilities.Permitted,
-		s.Process.Capabilities.Inheritable,
 	} {
 		if !capsContain(cl, "CAP_CHOWN") {
 			t.Errorf("cap list %d does not contain added cap", i)
@@ -585,7 +584,6 @@ func TestDropCaps(t *testing.T) {
 		s.Process.Capabilities.Bounding,
 		s.Process.Capabilities.Effective,
 		s.Process.Capabilities.Permitted,
-		s.Process.Capabilities.Inheritable,
 	} {
 		if capsContain(cl, "CAP_CHOWN") {
 			t.Errorf("cap list %d contains dropped cap", i)
@@ -604,7 +602,6 @@ func TestDropCaps(t *testing.T) {
 		s.Process.Capabilities.Bounding,
 		s.Process.Capabilities.Effective,
 		s.Process.Capabilities.Permitted,
-		s.Process.Capabilities.Inheritable,
 	} {
 		if capsContain(cl, "CAP_FOWNER") {
 			t.Errorf("cap list %d contains dropped cap", i)
@@ -625,7 +622,6 @@ func TestDropCaps(t *testing.T) {
 		s.Process.Capabilities.Bounding,
 		s.Process.Capabilities.Effective,
 		s.Process.Capabilities.Permitted,
-		s.Process.Capabilities.Inheritable,
 	} {
 		if len(cl) != 0 {
 			t.Errorf("cap list %d is not empty", i)

--- a/oci/spec_test.go
+++ b/oci/spec_test.go
@@ -44,7 +44,6 @@ func TestGenerateSpec(t *testing.T) {
 		for _, cl := range [][]string{
 			s.Process.Capabilities.Bounding,
 			s.Process.Capabilities.Permitted,
-			s.Process.Capabilities.Inheritable,
 			s.Process.Capabilities.Effective,
 		} {
 			for i := 0; i < len(defaults); i++ {
@@ -192,8 +191,8 @@ func TestWithCapabilities(t *testing.T) {
 	if len(s.Process.Capabilities.Permitted) != 1 || s.Process.Capabilities.Permitted[0] != "CAP_SYS_ADMIN" {
 		t.Error("Unexpected capabilities set")
 	}
-	if len(s.Process.Capabilities.Inheritable) != 1 || s.Process.Capabilities.Inheritable[0] != "CAP_SYS_ADMIN" {
-		t.Error("Unexpected capabilities set")
+	if len(s.Process.Capabilities.Inheritable) != 0 {
+		t.Errorf("Unexpected capabilities set: length is non zero (%d)", len(s.Process.Capabilities.Inheritable))
 	}
 }
 

--- a/pkg/cri/server/container_create_linux_test.go
+++ b/pkg/cri/server/container_create_linux_test.go
@@ -243,15 +243,14 @@ func TestContainerCapabilities(t *testing.T) {
 		for _, include := range test.includes {
 			assert.Contains(t, spec.Process.Capabilities.Bounding, include)
 			assert.Contains(t, spec.Process.Capabilities.Effective, include)
-			assert.Contains(t, spec.Process.Capabilities.Inheritable, include)
 			assert.Contains(t, spec.Process.Capabilities.Permitted, include)
 		}
 		for _, exclude := range test.excludes {
 			assert.NotContains(t, spec.Process.Capabilities.Bounding, exclude)
 			assert.NotContains(t, spec.Process.Capabilities.Effective, exclude)
-			assert.NotContains(t, spec.Process.Capabilities.Inheritable, exclude)
 			assert.NotContains(t, spec.Process.Capabilities.Permitted, exclude)
 		}
+		assert.Empty(t, spec.Process.Capabilities.Inheritable)
 		assert.Empty(t, spec.Process.Capabilities.Ambient)
 	}
 }


### PR DESCRIPTION
The Linux kernel never sets the Inheritable capability flag to
anything other than empty. Non-empty values are always exclusively
set by userspace code.

[The kernel stopped defaulting this set of capability values to the
 full set in 2000 after a privilege escalation with Capabilities
 affecting Sendmail and others.]

Signed-off-by: Andrew G. Morgan <morgan@kernel.org>
(cherry picked from commit [6906b57c721f9114377ceb069662b196876915c0](https://github.com/containerd/containerd/commit/6906b57c721f9114377ceb069662b196876915c0))
Signed-off-by: Samuel Karp <skarp@amazon.com>
(cherry picked from commit [69405249418ec66c6453763979ce02c72a75853f](https://github.com/containerd/containerd/commit/69405249418ec66c6453763979ce02c72a75853f))
Signed-off-by: Sebastiaan van Stijn <github@gone.nl>