### PR TITLE
[20.10 backport] containerd fixes for BuildKit 

### DIFF
--- a/remotes/docker/resolver.go
+++ b/remotes/docker/resolver.go
@@ -521,7 +521,10 @@ func (r *request) do(ctx context.Context) (*http.Response, error) {
 	if err != nil {
 		return nil, err
 	}
-	req.Header = r.header
+	req.Header = http.Header{} // headers need to be copied to avoid concurrent map access
+	for k, v := range r.header {
+		req.Header[k] = v
+	}
 	if r.body != nil {
 		body, err := r.body()
 		if err != nil {

--- a/snapshots/overlay/overlay_test.go
+++ b/snapshots/overlay/overlay_test.go
@@ -173,12 +173,21 @@ func testOverlayOverlayMount(t *testing.T, newSnapshotter testsuite.SnapshotterF
 		upper = "upperdir=" + filepath.Join(bp, "fs")
 		lower = "lowerdir=" + getParents(ctx, o, root, "/tmp/layer2")[0]
 	)
-	for i, v := range []string{
+
+	expected := []string{
 		"index=off",
+	}
+	if userxattr, err := NeedsUserXAttr(root); err != nil {
+		t.Fatal(err)
+	} else if userxattr {
+		expected = append(expected, "userxattr")
+	}
+	expected = append(expected, []string{
 		work,
 		upper,
 		lower,
-	} {
+	}...)
+	for i, v := range expected {
 		if m.Options[i] != v {
 			t.Errorf("expected %q but received %q", v, m.Options[i])
 		}
@@ -335,12 +344,26 @@ func testOverlayView(t *testing.T, newSnapshotter testsuite.SnapshotterFunc) {
 	if m.Source != "overlay" {
 		t.Errorf("mount source should be overlay but received %q", m.Source)
 	}
-	if len(m.Options) != 2 {
-		t.Errorf("expected 1 additional mount option but got %d", len(m.Options))
+
+	expectedOptions := 2
+	userxattr, err := NeedsUserXAttr(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if userxattr {
+		expectedOptions++
+	}
+
+	if len(m.Options) != expectedOptions {
+		t.Errorf("expected %d additional mount option but got %d", expectedOptions, len(m.Options))
 	}
 	lowers := getParents(ctx, o, root, "/tmp/view2")
 	expected = fmt.Sprintf("lowerdir=%s:%s", lowers[0], lowers[1])
-	if m.Options[1] != expected {
-		t.Errorf("expected option %q but received %q", expected, m.Options[0])
+	optIdx := 1
+	if userxattr {
+		optIdx++
+	}
+	if m.Options[optIdx] != expected {
+		t.Errorf("expected option %q but received %q", expected, m.Options[optIdx])
 	}
 }

--- a/snapshots/overlay/overlay_test.go
+++ b/snapshots/overlay/overlay_test.go
@@ -174,6 +174,7 @@ func testOverlayOverlayMount(t *testing.T, newSnapshotter testsuite.SnapshotterF
 		lower = "lowerdir=" + getParents(ctx, o, root, "/tmp/layer2")[0]
 	)
 	for i, v := range []string{
+		"index=off",
 		work,
 		upper,
 		lower,
@@ -334,12 +335,12 @@ func testOverlayView(t *testing.T, newSnapshotter testsuite.SnapshotterFunc) {
 	if m.Source != "overlay" {
 		t.Errorf("mount source should be overlay but received %q", m.Source)
 	}
-	if len(m.Options) != 1 {
-		t.Errorf("expected 1 mount option but got %d", len(m.Options))
+	if len(m.Options) != 2 {
+		t.Errorf("expected 1 additional mount option but got %d", len(m.Options))
 	}
 	lowers := getParents(ctx, o, root, "/tmp/view2")
 	expected = fmt.Sprintf("lowerdir=%s:%s", lowers[0], lowers[1])
-	if m.Options[0] != expected {
+	if m.Options[1] != expected {
 		t.Errorf("expected option %q but received %q", expected, m.Options[0])
 	}
 }


### PR DESCRIPTION
This applies the same fixes that were vendored in BuildKit through https://github.com/moby/buildkit/commit/2617f120e2dc6b69ee60cece4e6bac3dcb19abc9 (https://github.com/moby/buildkit/pull/2014). At the time we didn't want to vendor from a fork in Moby, but now that we already have a fork in place, we may as well backport these fixes.

Relates to:

- relates to https://github.com/moby/buildkit/pull/2014
- relates to https://github.com/moby/buildkit/pull/2013
- relates to https://github.com/containerd/containerd/issues/5060
- relates to https://github.com/moby/moby/issues/42055
- addresses https://github.com/containerd/containerd/issues/4795
- addresses https://github.com/moby/buildkit/issues/1867
- addresses https://github.com/moby/buildkit/issues/1983


Applying the changes that were added to Akihiro's fork;
https://github.com/containerd/containerd/compare/0edc412565dcc6e3d6125ff9e4b009ad4b89c638...AkihiroSuda:containerd:48f85a131bb8bb114f486f40cebfe1ba2fef653c

Backports:

- https://github.com/containerd/containerd/pull/4719
    - https://github.com/Akihirosuda/containerd/commit/5173ed35e2bc8396db8fd8db2b9d3f533937984a -> https://github.com/containerd/containerd/commit/85d9fe3e8ce823894fc47122f46da0dfabd9c657
- https://github.com/containerd/containerd/pull/5076
    - https://github.com/Akihirosuda/containerd/commit/4e5d7fefb0d82984dbf314c25ad8f00a649a5e30 -> https://github.com/containerd/containerd/commit/9ade247b38b5a685244e1391c86ff41ab109556e
- https://github.com/containerd/containerd/pull/4855
    - https://github.com/Akihirosuda/containerd/commit/48f85a131bb8bb114f486f40cebfe1ba2fef653c -> https://github.com/containerd/containerd/commit/bf323c5bdd5c9bdd2f957e03c4cdaa43e4c1c5a6
